### PR TITLE
Feature/kakao access token

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,4 +35,7 @@ out/
 
 ### VS Code ###
 .vscode/
+
+
 application.properties
+KakaoTestController.java

--- a/build.gradle
+++ b/build.gradle
@@ -31,6 +31,8 @@ dependencies {
 
 	implementation 'javax.xml.bind:jaxb-api:2.3.0'
 	implementation 'io.jsonwebtoken:jjwt:0.9.1'
+	implementation 'org.springframework.boot:spring-boot-starter-security'
+
 }
 
 tasks.named('test') {

--- a/build.gradle
+++ b/build.gradle
@@ -28,6 +28,9 @@ dependencies {
 	runtimeOnly 'com.h2database:h2'
 	annotationProcessor 'org.projectlombok:lombok'
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
+
+	implementation 'javax.xml.bind:jaxb-api:2.3.0'
+	implementation 'io.jsonwebtoken:jjwt:0.9.1'
 }
 
 tasks.named('test') {

--- a/src/main/java/com/tickettimer/backendserver/auth/PrincipalDetails.java
+++ b/src/main/java/com/tickettimer/backendserver/auth/PrincipalDetails.java
@@ -1,0 +1,65 @@
+package com.tickettimer.backendserver.auth;
+
+import com.tickettimer.backendserver.domain.Member;
+import lombok.Getter;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.userdetails.UserDetails;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+import java.util.Map;
+
+@Getter
+public class PrincipalDetails implements UserDetails {
+    private Member member;
+
+    public PrincipalDetails(Member member) {
+        this.member=member;
+    }
+
+
+
+    @Override
+    public Collection<? extends GrantedAuthority> getAuthorities() {
+        Collection<GrantedAuthority> collect = new ArrayList<>();
+        collect.add(new GrantedAuthority() {
+            @Override
+            public String getAuthority() {
+                return "ROLE_USER";
+            }
+        });
+        return collect;
+    }
+
+    @Override
+    public String getPassword() {
+        return null;
+    }
+
+    @Override
+    public String getUsername() {
+        return this.member.getServerId();
+    }
+
+    @Override
+    public boolean isAccountNonExpired() {
+        return true;
+    }
+
+    @Override
+    public boolean isAccountNonLocked() {
+        return true;
+    }
+
+    @Override
+    public boolean isCredentialsNonExpired() {
+        return true;
+    }
+
+    @Override
+    public boolean isEnabled() {
+        return true;
+    }
+
+}

--- a/src/main/java/com/tickettimer/backendserver/config/BeanConfig.java
+++ b/src/main/java/com/tickettimer/backendserver/config/BeanConfig.java
@@ -1,0 +1,24 @@
+package com.tickettimer.backendserver.config;
+
+import com.fasterxml.jackson.databind.DeserializationFeature;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.module.SimpleModule;
+import com.tickettimer.backendserver.dto.TokenType;
+import org.antlr.v4.runtime.Token;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class BeanConfig {
+    @Bean
+    public ObjectMapper objectMapper() {
+        ObjectMapper objectMapper = new ObjectMapper();
+        SimpleModule simpleModule = new SimpleModule();
+        simpleModule.addSerializer(TokenType.class, new TokenTypeSerializer()); // YourEnumSerializer는 Enum을 String으로 직렬화하는 커스텀 Serializer 클래스입니다.
+        objectMapper.registerModule(simpleModule);
+
+        // Enum 값을 String에서 Enum으로 역직렬화하기 위한 설정
+        objectMapper.configure(DeserializationFeature.READ_UNKNOWN_ENUM_VALUES_AS_NULL, true);
+        return objectMapper;
+    }
+}

--- a/src/main/java/com/tickettimer/backendserver/config/SecurityConfig.java
+++ b/src/main/java/com/tickettimer/backendserver/config/SecurityConfig.java
@@ -1,0 +1,62 @@
+package com.tickettimer.backendserver.config;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.tickettimer.backendserver.filter.AuthorizationExceptionFilter;
+import com.tickettimer.backendserver.filter.JwtAuthorizationFilter;
+import com.tickettimer.backendserver.service.JwtService;
+import com.tickettimer.backendserver.service.PrincipalDetailsService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.authentication.AuthenticationManager;
+import org.springframework.security.config.Customizer;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
+import org.springframework.security.config.http.SessionCreationPolicy;
+import org.springframework.security.web.SecurityFilterChain;
+
+@Configuration
+@EnableWebSecurity
+@RequiredArgsConstructor
+public class SecurityConfig {
+    private final ObjectMapper objectMapper;
+    private final JwtService jwtService;
+    private final PrincipalDetailsService principalDetailsService;
+    @Bean
+    public SecurityFilterChain securityFilterChain(HttpSecurity httpSecurity) throws Exception{
+        httpSecurity.httpBasic(Customizer.withDefaults());
+        httpSecurity.formLogin(Customizer.withDefaults());
+        httpSecurity.formLogin(
+                formLogin -> formLogin.disable()
+        );
+        httpSecurity.httpBasic(
+                httpBasic -> httpBasic.disable()
+        );
+        httpSecurity.csrf(
+                csrf -> csrf.disable()
+        );
+        httpSecurity.sessionManagement(
+                sessionManagement -> sessionManagement.sessionCreationPolicy(SessionCreationPolicy.STATELESS)
+        );
+        httpSecurity.apply(new MyCustom());
+        httpSecurity.authorizeHttpRequests(
+                request->request.requestMatchers("/api/oauth2/kakao").permitAll()
+                        .requestMatchers("/login/oauth2/code/kakao").permitAll()
+                        .anyRequest().authenticated()
+        );
+        return httpSecurity.build();
+    }
+
+    public class MyCustom extends AbstractHttpConfigurer<MyCustom, HttpSecurity> {
+        @Override
+        public void configure(HttpSecurity http) {
+            AuthenticationManager authenticationManager = http.getSharedObject(AuthenticationManager.class);
+            http
+                    .addFilter(new JwtAuthorizationFilter(authenticationManager, jwtService, principalDetailsService, objectMapper))
+                    .addFilterBefore(new AuthorizationExceptionFilter(objectMapper), JwtAuthorizationFilter.class);
+
+        }
+    }
+
+}

--- a/src/main/java/com/tickettimer/backendserver/config/TokenTypeSerializer.java
+++ b/src/main/java/com/tickettimer/backendserver/config/TokenTypeSerializer.java
@@ -1,0 +1,16 @@
+package com.tickettimer.backendserver.config;
+
+import com.fasterxml.jackson.core.JsonGenerator;
+import com.fasterxml.jackson.databind.JsonSerializer;
+import com.fasterxml.jackson.databind.SerializerProvider;
+import com.tickettimer.backendserver.dto.TokenType;
+
+import java.io.IOException;
+
+public class TokenTypeSerializer extends JsonSerializer<TokenType> {
+
+    @Override
+    public void serialize(TokenType value, JsonGenerator jsonGenerator, SerializerProvider serializers) throws IOException {
+        jsonGenerator.writeString(value.toString());
+    }
+}

--- a/src/main/java/com/tickettimer/backendserver/controller/OAuth2Controller.java
+++ b/src/main/java/com/tickettimer/backendserver/controller/OAuth2Controller.java
@@ -24,6 +24,11 @@ public class OAuth2Controller {
     private final ObjectMapper objectMapper;
     private final MemberRepository memberRepository;
     private final JwtService jwtService;
+
+    @GetMapping("/")
+    public String hello() {
+        return "hello";
+    }
     @GetMapping("/kakao")
     public ResponseEntity<TokenInfo> getAccessAndRefresh(@RequestHeader("access-token") String kakaoAccessToken) {
         // header 생성
@@ -54,8 +59,8 @@ public class OAuth2Controller {
         String nickname = (String) properties.get("nickname");
 
         // 이메일
-        String email = (String)kakaoAccount.get("email");
-        System.out.println(serverId+ nickname+ email);
+        String email = (String) kakaoAccount.get("email");
+        System.out.println(serverId + nickname + email);
         Optional<Member> findMember = memberRepository.findByServerId(serverId);
 
         Member member = null;
@@ -65,9 +70,8 @@ public class OAuth2Controller {
                     .serverId(serverId)
                     .nickname(nickname)
                     .email(email).build();
-            member=memberRepository.save(newMember);
-        }
-        else{
+            member = memberRepository.save(newMember);
+        } else {
             member = findMember.get();
         }
         String accessToken = jwtService.createAccessToken(
@@ -75,7 +79,7 @@ public class OAuth2Controller {
                 member.getId()
         );
 
-        String refreshToken = jwtService.createRefreshToken(member.getId());
+        String refreshToken = jwtService.createRefreshToken(member.getServerId(), member.getId());
         TokenInfo tokenInfo = TokenInfo.builder()
                 .accessToken(accessToken)
                 .refreshToken(refreshToken).build();

--- a/src/main/java/com/tickettimer/backendserver/controller/OAuth2Controller.java
+++ b/src/main/java/com/tickettimer/backendserver/controller/OAuth2Controller.java
@@ -1,0 +1,87 @@
+package com.tickettimer.backendserver.controller;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.tickettimer.backendserver.domain.Member;
+import com.tickettimer.backendserver.dto.TokenInfo;
+import com.tickettimer.backendserver.repository.MemberRepository;
+import com.tickettimer.backendserver.service.JwtService;
+import com.tickettimer.backendserver.service.MemberService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.*;
+import org.springframework.util.LinkedMultiValueMap;
+import org.springframework.util.MultiValueMap;
+import org.springframework.web.bind.annotation.*;
+import org.springframework.web.client.RestTemplate;
+
+import java.util.Map;
+import java.util.Optional;
+
+
+@RequestMapping("/api/oauth2")
+@RestController
+@RequiredArgsConstructor
+public class OAuth2Controller {
+    private final ObjectMapper objectMapper;
+    private final MemberRepository memberRepository;
+    private final JwtService jwtService;
+    @GetMapping("/kakao")
+    public ResponseEntity<TokenInfo> getAccessAndRefresh(@RequestHeader("access-token") String kakaoAccessToken) {
+        // header 생성
+        HttpHeaders httpHeaders = new HttpHeaders();
+        httpHeaders.add(HttpHeaders.AUTHORIZATION, kakaoAccessToken);
+        httpHeaders.add(HttpHeaders.CONTENT_TYPE, "application/x-www-form-urlencoded;charset=utf-8");
+
+        HttpEntity<MultiValueMap<String, String>> httpEntity = new HttpEntity<>(httpHeaders);
+
+        // 사용자 정보 요청하기
+        RestTemplate restTemplate = new RestTemplate();
+        ResponseEntity<Object> response = restTemplate.exchange(
+                "https://kapi.kakao.com/v2/user/me",
+                HttpMethod.GET,
+                httpEntity,
+                Object.class
+        );
+        Map map = objectMapper.convertValue(response.getBody(), Map.class);
+        System.out.println("response = " + response.getBody());
+        System.out.println("map = " + map);
+        Map properties = objectMapper.convertValue(map.get("properties"), Map.class);
+        Map kakaoAccount = objectMapper.convertValue(map.get("kakao_account"), Map.class);
+
+        // 서버 식별 아이디
+        String serverId = "kakao" + map.get("id");
+
+        // 닉네임
+        String nickname = (String) properties.get("nickname");
+
+        // 이메일
+        String email = (String)kakaoAccount.get("email");
+        System.out.println(serverId+ nickname+ email);
+        Optional<Member> findMember = memberRepository.findByServerId(serverId);
+
+        Member member = null;
+        // 유저가 데이터베이스에 없으면 회원가입 처리
+        if (findMember.isEmpty()) {
+            Member newMember = Member.builder()
+                    .serverId(serverId)
+                    .nickname(nickname)
+                    .email(email).build();
+            member=memberRepository.save(newMember);
+        }
+        else{
+            member = findMember.get();
+        }
+        String accessToken = jwtService.createAccessToken(
+                member.getServerId(),
+                member.getId()
+        );
+
+        String refreshToken = jwtService.createRefreshToken(member.getId());
+        TokenInfo tokenInfo = TokenInfo.builder()
+                .accessToken(accessToken)
+                .refreshToken(refreshToken).build();
+        return new ResponseEntity<>(tokenInfo, HttpStatus.OK);
+
+
+    }
+
+}

--- a/src/main/java/com/tickettimer/backendserver/domain/Member.java
+++ b/src/main/java/com/tickettimer/backendserver/domain/Member.java
@@ -2,16 +2,14 @@ package com.tickettimer.backendserver.domain;
 
 
 import jakarta.persistence.*;
-import lombok.AllArgsConstructor;
-import lombok.Builder;
-import lombok.Getter;
-import lombok.Setter;
+import lombok.*;
 
 import java.util.ArrayList;
 import java.util.List;
 
 @Getter
 @Entity
+@NoArgsConstructor
 @Table(name="MEMBER")
 public class Member {
 

--- a/src/main/java/com/tickettimer/backendserver/dto/AuthorizationRequest.java
+++ b/src/main/java/com/tickettimer/backendserver/dto/AuthorizationRequest.java
@@ -1,0 +1,19 @@
+package com.tickettimer.backendserver.dto;
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+public class AuthorizationRequest {
+    private TokenType type;
+    private String token;
+
+    @Builder
+    public AuthorizationRequest(TokenType type, String token) {
+        this.token=token;
+        this.type=type;
+    }
+    public AuthorizationRequest() {
+
+    }
+}

--- a/src/main/java/com/tickettimer/backendserver/dto/ResultResponse.java
+++ b/src/main/java/com/tickettimer/backendserver/dto/ResultResponse.java
@@ -1,0 +1,17 @@
+package com.tickettimer.backendserver.dto;
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+public class ResultResponse {
+    private int code;
+    private String message;
+    private Object result;
+    @Builder
+    public ResultResponse(int code, String message, Object result) {
+        this.code=code;
+        this.message=message;
+        this.result=result;
+    }
+}

--- a/src/main/java/com/tickettimer/backendserver/dto/TokenInfo.java
+++ b/src/main/java/com/tickettimer/backendserver/dto/TokenInfo.java
@@ -1,0 +1,17 @@
+package com.tickettimer.backendserver.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+public class TokenInfo {
+    private String accessToken;
+    private String refreshToken;
+
+    @Builder
+    public TokenInfo(String accessToken, String refreshToken) {
+        this.accessToken=accessToken;
+        this.refreshToken=refreshToken;
+    }
+}

--- a/src/main/java/com/tickettimer/backendserver/dto/TokenType.java
+++ b/src/main/java/com/tickettimer/backendserver/dto/TokenType.java
@@ -1,0 +1,12 @@
+package com.tickettimer.backendserver.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+@AllArgsConstructor
+@Getter
+public enum TokenType {
+    ACCESS("accessToken"),
+    REFRESH("refreshToken");
+    private String name;
+
+}

--- a/src/main/java/com/tickettimer/backendserver/exception/CustomExceptionManager.java
+++ b/src/main/java/com/tickettimer/backendserver/exception/CustomExceptionManager.java
@@ -1,0 +1,46 @@
+package com.tickettimer.backendserver.exception;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.validation.BindingResult;
+import org.springframework.validation.ObjectError;
+import org.springframework.web.bind.MethodArgumentNotValidException;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+import java.util.List;
+
+@RestControllerAdvice
+@Slf4j
+public class CustomExceptionManager {
+    ObjectMapper mapper = new ObjectMapper();
+//    @ExceptionHandler(MethodArgumentNotValidException.class)
+//    public ResponseEntity<ResultResponse> requestException(MethodArgumentNotValidException ex, BindingResult bindingResult) throws JsonProcessingException, NoSuchFieldException, IllegalAccessException {
+//        List<ObjectError> allErrors = bindingResult.getAllErrors();
+//        for (ObjectError error : allErrors) {
+//            System.out.println("error = " + error);
+//            System.out.println("error = " + error.getArguments());
+//        }
+//        ResultResponse res = ResultResponse.builder()
+//                .code(HttpStatus.BAD_REQUEST.value())
+//                .message(bindingResult.getAllErrors().get(0).getDefaultMessage())
+//                .build();
+//
+//        return new ResponseEntity<>(res, HttpStatus.BAD_REQUEST);
+//    }
+//    @ExceptionHandler(CustomNotFoundException.class)
+//    public ResponseEntity<ResultResponse> notFoundException(CustomNotFoundException ex) {
+//        ResultResponse res = ResultResponse.builder()
+//                .code(HttpStatus.NOT_FOUND.value())
+//                .message(ex.getMessage())
+//                .result(ex.getObject())
+//                .build();
+//        return new ResponseEntity<>(res, HttpStatus.NOT_FOUND);
+//    }
+
+
+
+}

--- a/src/main/java/com/tickettimer/backendserver/exception/CustomNotFoundException.java
+++ b/src/main/java/com/tickettimer/backendserver/exception/CustomNotFoundException.java
@@ -1,0 +1,11 @@
+package com.tickettimer.backendserver.exception;
+
+import lombok.Getter;
+
+@Getter
+public class CustomNotFoundException extends RuntimeException{
+    // Not Found : memberId=abc123
+    public CustomNotFoundException(String field, String value) {
+        super("Not Found : ".concat(field).concat("=").concat(value));
+    }
+}

--- a/src/main/java/com/tickettimer/backendserver/exception/InvalidTokenException.java
+++ b/src/main/java/com/tickettimer/backendserver/exception/InvalidTokenException.java
@@ -1,0 +1,7 @@
+package com.tickettimer.backendserver.exception;
+
+public class InvalidTokenException extends RuntimeException {
+    public InvalidTokenException() {
+        super("유효하지 않은 토큰입니다.");
+    }
+}

--- a/src/main/java/com/tickettimer/backendserver/filter/AuthorizationExceptionFilter.java
+++ b/src/main/java/com/tickettimer/backendserver/filter/AuthorizationExceptionFilter.java
@@ -1,0 +1,65 @@
+package com.tickettimer.backendserver.filter;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.tickettimer.backendserver.dto.ResultResponse;
+import com.tickettimer.backendserver.dto.TokenInfo;
+import com.tickettimer.backendserver.exception.CustomNotFoundException;
+import com.tickettimer.backendserver.exception.InvalidTokenException;
+import io.jsonwebtoken.ExpiredJwtException;
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+import java.io.IOException;
+import java.io.PrintWriter;
+
+public class AuthorizationExceptionFilter extends OncePerRequestFilter {
+    private final ObjectMapper objectMapper;
+
+    public AuthorizationExceptionFilter(ObjectMapper objectMapper) {
+        this.objectMapper = objectMapper;
+    }
+    @Override
+    protected void doFilterInternal(
+            HttpServletRequest request,
+            HttpServletResponse response,
+            FilterChain filterChain
+    ) throws ServletException, IOException {
+        try {
+            filterChain.doFilter(request, response);
+            String accessToken = (String) request.getAttribute("access");
+            String refreshToken = (String) request.getAttribute("refresh");
+            TokenInfo tokenInfo = TokenInfo.builder()
+                    .accessToken(accessToken)
+                    .refreshToken(refreshToken)
+                    .build();
+//            writeErrorResponse(response, HttpStatus.OK.value(), "토큰 재생성 완료했습니다.", tokenInfo);
+        } catch (CustomNotFoundException ex) {
+            writeErrorResponse(response, HttpStatus.NOT_FOUND.value(), ex.getMessage(), null);
+        } catch (InvalidTokenException ex) {
+            writeErrorResponse(response, HttpStatus.BAD_REQUEST.value(), ex.getMessage(), null);
+        } catch (ExpiredJwtException ex) {
+            writeErrorResponse(response, HttpStatus.UNAUTHORIZED.value(), ex.getMessage(), null);
+        }
+    }
+    private void writeErrorResponse(HttpServletResponse response, int status, String message, Object result) {
+        response.setStatus(status);
+        response.setContentType(MediaType.APPLICATION_JSON_VALUE);
+        response.setCharacterEncoding("utf-8");
+        ResultResponse res = ResultResponse.builder()
+                .code(status)
+                .message(message)
+                .result(result).build();
+        try {
+            String s = objectMapper.writeValueAsString(res);
+            PrintWriter writer = response.getWriter();
+            writer.write(s);
+        } catch (IOException ex) {
+            throw new RuntimeException(ex);
+        }
+    }
+}

--- a/src/main/java/com/tickettimer/backendserver/filter/JwtAuthorizationFilter.java
+++ b/src/main/java/com/tickettimer/backendserver/filter/JwtAuthorizationFilter.java
@@ -1,0 +1,130 @@
+package com.tickettimer.backendserver.filter;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.tickettimer.backendserver.auth.PrincipalDetails;
+import com.tickettimer.backendserver.dto.AuthorizationRequest;
+import com.tickettimer.backendserver.dto.ResultResponse;
+import com.tickettimer.backendserver.dto.TokenInfo;
+import com.tickettimer.backendserver.dto.TokenType;
+import com.tickettimer.backendserver.exception.CustomNotFoundException;
+import com.tickettimer.backendserver.exception.InvalidTokenException;
+import com.tickettimer.backendserver.service.JwtService;
+import com.tickettimer.backendserver.service.MemberService;
+import com.tickettimer.backendserver.service.PrincipalDetailsService;
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.security.authentication.AuthenticationManager;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.security.web.authentication.www.BasicAuthenticationFilter;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.PrintWriter;
+
+/**
+ * 반환 에러 종류
+ * CustomNotFoundException : 멤버를 찾지 못 함
+ * InvalidTokenException : jwt의 형태가 아님
+ * ExpiredJwtException : jwt의 유효 기간이 만료 됨
+ */
+@Slf4j
+public class JwtAuthorizationFilter extends BasicAuthenticationFilter {
+    private final JwtService jwtService;
+    private final PrincipalDetailsService principalDetailsService;
+    private final ObjectMapper objectMapper;
+
+    public JwtAuthorizationFilter(
+            AuthenticationManager authenticationManager,
+            JwtService jwtService,
+            PrincipalDetailsService principalDetailsService,
+            ObjectMapper objectMapper) {
+        super(authenticationManager);
+        this.jwtService=jwtService;
+        this.principalDetailsService=principalDetailsService;
+        this.objectMapper=objectMapper;
+    }
+    @Override
+    protected void doFilterInternal(
+            HttpServletRequest request,
+            HttpServletResponse response,
+            FilterChain chain
+    ) throws IOException, ServletException {
+        String jwt = request.getHeader("Authorization");
+        //jwt가 없거나 Bearer로 시작하지 않으면 거부
+        if (jwt == null || !jwt.startsWith("Bearer")) {
+            String path =request.getContextPath() + request.getServletPath();
+            if (
+                    path.equals("/login/oauth2/code/kakao") ||
+                            path.equals("/api/oauth2/kakao")
+            ) {
+                chain.doFilter(request, response);
+                return;
+            }
+            throw new InvalidTokenException();
+        }
+
+
+        String token = jwt.replace("Bearer ", "");
+        String tokenType = jwtService.getTokenType(token);
+
+        // refresh token이라면 검증 후 access token과 refresh token 재생성 후 반환
+        // refresh token이 만료되었다면 ExpiredJwtException 에러 발생
+        if (tokenType.equals(TokenType.REFRESH.getName())) {
+            Long id = jwtService.getId(token);
+            String serverId = jwtService.getServerId(token);
+            String accessToken = jwtService.createAccessToken(serverId, id);
+            String refreshToken = jwtService.createRefreshToken(serverId, id);
+            TokenInfo tokenInfo = TokenInfo.builder()
+                    .accessToken(accessToken)
+                    .refreshToken(refreshToken)
+                    .build();
+            writeTokenResponse(response,"토큰을 재생성하였습니다.",tokenInfo);
+            return;
+        }
+
+        // 만약 access token이었다면 검증 진행 후 성공한다면 Authentication 객체를 SecurityContextHolder에 넣음
+        System.out.println("tokenType = " + tokenType);
+        String serverId = jwtService.getServerId(token);
+        PrincipalDetails principalDetails = (PrincipalDetails) principalDetailsService.loadUserByUsername(serverId);
+        Authentication authentication = new UsernamePasswordAuthenticationToken(
+                principalDetails,
+                null,
+                principalDetails.getAuthorities()
+        );
+        SecurityContextHolder.getContext().setAuthentication(authentication);
+        log.info("id : {} 접근 권한이 존재합니다.", serverId);
+        chain.doFilter(request, response);
+    }
+
+    /**
+     *
+     * @param response HttpServletResponse
+     * @param message 토큰 생성 메시지
+     * @param result TokenInfo 객체
+     */
+
+    private void writeTokenResponse(HttpServletResponse response, String message, TokenInfo result) {
+        response.setStatus(HttpStatus.OK.value());
+        response.setContentType(MediaType.APPLICATION_JSON_VALUE);
+        response.setCharacterEncoding("utf-8");
+        ResultResponse res = ResultResponse.builder()
+                .code(response.getStatus())
+                .message(message)
+                .result(result).build();
+        try {
+            String s = objectMapper.writeValueAsString(res);
+            PrintWriter writer = response.getWriter();
+            writer.write(s);
+        } catch (IOException ex) {
+            throw new RuntimeException(ex);
+        }
+    }
+}

--- a/src/main/java/com/tickettimer/backendserver/repository/MemberRepository.java
+++ b/src/main/java/com/tickettimer/backendserver/repository/MemberRepository.java
@@ -4,6 +4,10 @@ import com.tickettimer.backendserver.domain.Member;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
+import java.util.Optional;
+
 @Repository
 public interface MemberRepository extends JpaRepository<Member, Long> {
+    Member save(Member member);
+    Optional<Member> findByServerId(String serverId);
 }

--- a/src/main/java/com/tickettimer/backendserver/service/JwtService.java
+++ b/src/main/java/com/tickettimer/backendserver/service/JwtService.java
@@ -1,0 +1,70 @@
+package com.tickettimer.backendserver.service;
+
+import io.jsonwebtoken.Claims;
+import io.jsonwebtoken.ExpiredJwtException;
+import io.jsonwebtoken.Jwts;
+import io.jsonwebtoken.SignatureAlgorithm;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+
+import java.util.Date;
+
+@Service
+public class JwtService {
+//    private final TokenRepository tokenRepository;
+    @Value("${jwt.secretKey}") //application.properties에 저장되어 있는 값을 가져온다.
+    private String secretKey;
+    @Value("${jwt.expiredMs}") //application.properties에 저장되어 있는 값을 가져온다.
+    private Long expiredMs;
+
+    public String getMemberId(String token) {
+        return Jwts.parser().setSigningKey(secretKey).parseClaimsJws(token)
+                .getBody().get("memberId", String.class);
+    }
+    public Long getId(String token) {
+        return Jwts.parser().setSigningKey(secretKey).parseClaimsJws(token)
+                .getBody().get("id", Long.class);
+    }
+
+    public boolean isExpired(String token) {
+        return !Jwts.parser().setSigningKey(secretKey).parseClaimsJws(token)
+                .getBody().getExpiration().before(new Date());
+    }
+
+    public String createAccessToken(String memberServerId, Long id) {
+        Claims claims = Jwts.claims();
+        claims.put("memberId", memberServerId);
+        claims.put("id", id);
+
+        String token = Jwts.builder()
+                .setClaims(claims)
+                .setIssuedAt(new Date(System.currentTimeMillis()))
+                .setExpiration(new Date(System.currentTimeMillis() + expiredMs))
+                .signWith(SignatureAlgorithm.HS256, secretKey)
+                .compact();
+        return token;
+    }
+    public String createRefreshToken(Long id) {
+        Claims claims = Jwts.claims();
+        claims.put("id", id);
+
+        String token = Jwts.builder()
+                .setClaims(claims)
+                .setIssuedAt(new Date(System.currentTimeMillis()))
+                .setExpiration(new Date(System.currentTimeMillis() + expiredMs))
+                .signWith(SignatureAlgorithm.HS256, secretKey)
+                .compact();
+//        Token token1 = new Token(id, token);
+//        tokenRepository.save(token1);
+        return token;
+    }
+
+//    public boolean validateRefreshToken(String refreshToken) {
+//        boolean expired = isExpired(refreshToken);
+//        System.out.println("expired = " + expired);
+//        Long pk = getId(refreshToken);
+////        String storedRefreshToken = tokenRepository.findById(pk).get().toString();
+//        return expired && refreshToken.equals(storedRefreshToken);
+//
+//    }
+}

--- a/src/main/java/com/tickettimer/backendserver/service/MemberService.java
+++ b/src/main/java/com/tickettimer/backendserver/service/MemberService.java
@@ -1,0 +1,31 @@
+package com.tickettimer.backendserver.service;
+
+import com.tickettimer.backendserver.domain.Member;
+import com.tickettimer.backendserver.exception.CustomNotFoundException;
+import com.tickettimer.backendserver.repository.MemberRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.util.Optional;
+
+@Service
+@RequiredArgsConstructor
+public class MemberService {
+//    private final MemberRepository memberRepository;
+//
+//    public Member save(Member member) {
+//        Optional<Member> save = memberRepository.save(member);
+//        return save.orElseThrow(
+//                () -> new CustomNotFoundException("memberId", member.getServerId())
+//        );
+//    }
+//
+//    public Member findById(Long id) {
+//        Optional<Member> findMember = memberRepository.findById(id);
+//        findMember.ifPresent(
+//                value->{
+//
+//                }
+//        );
+//    }
+}

--- a/src/main/java/com/tickettimer/backendserver/service/PrincipalDetailsService.java
+++ b/src/main/java/com/tickettimer/backendserver/service/PrincipalDetailsService.java
@@ -1,0 +1,35 @@
+package com.tickettimer.backendserver.service;
+
+import com.tickettimer.backendserver.auth.PrincipalDetails;
+import com.tickettimer.backendserver.domain.Member;
+import com.tickettimer.backendserver.exception.CustomNotFoundException;
+import com.tickettimer.backendserver.repository.MemberRepository;
+import jakarta.transaction.Transactional;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.security.core.userdetails.UserDetailsService;
+import org.springframework.stereotype.Service;
+
+import java.util.Optional;
+
+@RequiredArgsConstructor
+@Service
+public class PrincipalDetailsService implements UserDetailsService{
+    private final MemberRepository memberRepository;
+
+    /**
+     *
+     * @param serverId resource server 정보 조합한 아이디. 식별 목적.
+     * @return Member 엔티티를 담은 PrincipalDetails
+     * 만약 해당 serverId가 데이터베이스에 없으면 CustomNotFoundException 발생.
+     */
+    @Override
+    public UserDetails loadUserByUsername(String serverId) {
+        Optional<Member> member = memberRepository.findByServerId(serverId);
+        member.orElseThrow(
+                () -> new CustomNotFoundException("serverId", serverId)
+        );
+
+        return new PrincipalDetails(member.get());
+    }
+}


### PR DESCRIPTION
## 🌱 관련 이슈
- #2 
<!-- 관련있는 이슈 번호(#000)을 적어주세요. -->


## 🌱 구현/변경 사항 및 이유
1. 인증 및 인가 구현
2. repostiory 생성
3. 카카오 access token 받아서 유저 정보 저장
4. JwtService 추가 


<!-- 구현/변경한 내용과 및 이유를 적어주세요. -->


## 🌱 PR Point
시큐리티 필터를 사용하여 access token과 refresh token을 통한 인증 및 인가 구현했습니다.

jwt의 Claim에 토큰 타입(accessToken, refreshToken) 담겨있습니다. 서버에서 access token인지 refresh token인지 구별할 때 사용합니다.

Authorization header에 jwt를 넣어서 보내주면 JwtAuthorizationFilter에서 해당 토큰의 타입을 구별하고 타입에 따라 다음과 같은 과정을 진행합니다.

- Access token일 경우
  유효성 검증을 하고 성공한다면 통과, 실패한다면 401 에러 반환
- Refresh token일 경우
  유효성 검증을 하고 성공한다면 새로 access token, refresh token 발급 후 반환, 실패한다면 401 에러 반환

시큐리티 필터의 에러 체크는 AuthorizationExceptionFilter에서 진행합니다.
AuthorizationExceptionFilter는 JwtAuthorizationFilter 이전에 존재하고 JwtAuthorizationFilter에서 반환된 에러를 잡아서 처리합니다.

application.properties 파일의 경우 .gitignore에 등록되어있습니다.
따로 보내드린 application.properties 파일을 로컬에 등록해서 사용해주시길 바랍니다.
application.properties에는 민감한 정보들이 담길 예정이라 깃허브에 올라가지 않게 주의해주세요.

컨트롤러에서 발생한 에러는 전부 CustomExceptionManager에서 처리할 예정입니다.

<!-- 리뷰어 분들이 집중적으로 보셨으면 하는 내용을 적어주세요 -->


## 🌱 스크린샷

<!-- 참고할 스크린샷을 넣어주세요. -->
![image](https://github.com/TIcket-Timer/backend/assets/105545215/443fb6c4-7cce-4623-9292-21cee0f2effa)


## 🌱 참고한 코드 출처
- []()
<!-- 참고한 코드의 출처를 작성해주세요 -->
