### PR TITLE
[Refactor] 인증 부분 컨트롤러에서 시큐리티 필터로 변경

### DIFF
--- a/src/main/java/com/tickettimer/backendserver/auth/PrincipalDetails.java
+++ b/src/main/java/com/tickettimer/backendserver/auth/PrincipalDetails.java
@@ -34,7 +34,7 @@ public class PrincipalDetails implements UserDetails {
 
     @Override
     public String getPassword() {
-        return null;
+        return this.member.getPassword();
     }
 
     @Override

--- a/src/main/java/com/tickettimer/backendserver/config/BeanConfig.java
+++ b/src/main/java/com/tickettimer/backendserver/config/BeanConfig.java
@@ -7,6 +7,9 @@ import com.tickettimer.backendserver.dto.TokenType;
 import org.antlr.v4.runtime.Token;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.security.authentication.AuthenticationManager;
+import org.springframework.security.config.annotation.authentication.configuration.AuthenticationConfiguration;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 
 @Configuration
 public class BeanConfig {
@@ -20,5 +23,10 @@ public class BeanConfig {
         // Enum 값을 String에서 Enum으로 역직렬화하기 위한 설정
         objectMapper.configure(DeserializationFeature.READ_UNKNOWN_ENUM_VALUES_AS_NULL, true);
         return objectMapper;
+    }
+
+    @Bean
+    public BCryptPasswordEncoder bCryptPasswordEncoder() {
+        return new BCryptPasswordEncoder();
     }
 }

--- a/src/main/java/com/tickettimer/backendserver/config/SecurityConfig.java
+++ b/src/main/java/com/tickettimer/backendserver/config/SecurityConfig.java
@@ -1,11 +1,15 @@
 package com.tickettimer.backendserver.config;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.tickettimer.backendserver.filter.AuthenticationExceptionFilter;
 import com.tickettimer.backendserver.filter.AuthorizationExceptionFilter;
+import com.tickettimer.backendserver.filter.JwtAuthenticationFilter;
 import com.tickettimer.backendserver.filter.JwtAuthorizationFilter;
 import com.tickettimer.backendserver.service.JwtService;
+import com.tickettimer.backendserver.service.MemberService;
 import com.tickettimer.backendserver.service.PrincipalDetailsService;
 import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.security.authentication.AuthenticationManager;
@@ -14,6 +18,7 @@ import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
 import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
 import org.springframework.security.config.http.SessionCreationPolicy;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.security.web.SecurityFilterChain;
 
 @Configuration
@@ -23,10 +28,13 @@ public class SecurityConfig {
     private final ObjectMapper objectMapper;
     private final JwtService jwtService;
     private final PrincipalDetailsService principalDetailsService;
+    private final MemberService memberService;
+    private final BCryptPasswordEncoder bCryptPasswordEncoder;
+    @Value("${oauth2.member.kakao.password}")
+    private String password;
+
     @Bean
-    public SecurityFilterChain securityFilterChain(HttpSecurity httpSecurity) throws Exception{
-        httpSecurity.httpBasic(Customizer.withDefaults());
-        httpSecurity.formLogin(Customizer.withDefaults());
+    public SecurityFilterChain securityFilterChain(HttpSecurity httpSecurity) throws Exception {
         httpSecurity.formLogin(
                 formLogin -> formLogin.disable()
         );
@@ -41,7 +49,7 @@ public class SecurityConfig {
         );
         httpSecurity.apply(new MyCustom());
         httpSecurity.authorizeHttpRequests(
-                request->request.requestMatchers("/api/oauth2/kakao").permitAll()
+                request -> request.requestMatchers("/api/oauth2/kakao").permitAll()
                         .requestMatchers("/login/oauth2/code/kakao").permitAll()
                         .anyRequest().authenticated()
         );
@@ -52,8 +60,25 @@ public class SecurityConfig {
         @Override
         public void configure(HttpSecurity http) {
             AuthenticationManager authenticationManager = http.getSharedObject(AuthenticationManager.class);
+            JwtAuthenticationFilter jwtAuthenticationFilter = new JwtAuthenticationFilter(
+                    authenticationManager,
+                    memberService,
+                    objectMapper,
+                    jwtService,
+                    bCryptPasswordEncoder,
+                    password
+            );
+            jwtAuthenticationFilter.setFilterProcessesUrl("/api/oauth2/kakao");
             http
-                    .addFilter(new JwtAuthorizationFilter(authenticationManager, jwtService, principalDetailsService, objectMapper))
+                    .addFilter(jwtAuthenticationFilter)
+                    .addFilterBefore(new AuthenticationExceptionFilter(objectMapper), JwtAuthenticationFilter.class)
+                    .addFilter(
+                    new JwtAuthorizationFilter(
+                            authenticationManager,
+                            jwtService,
+                            principalDetailsService,
+                            objectMapper)
+            )
                     .addFilterBefore(new AuthorizationExceptionFilter(objectMapper), JwtAuthorizationFilter.class);
 
         }

--- a/src/main/java/com/tickettimer/backendserver/controller/OAuth2Controller.java
+++ b/src/main/java/com/tickettimer/backendserver/controller/OAuth2Controller.java
@@ -18,7 +18,6 @@ import java.util.Optional;
 
 
 @RequestMapping("/api/oauth2")
-@RestController
 @RequiredArgsConstructor
 public class OAuth2Controller {
     private final ObjectMapper objectMapper;
@@ -70,7 +69,7 @@ public class OAuth2Controller {
                     .serverId(serverId)
                     .nickname(nickname)
                     .email(email).build();
-            member = memberRepository.save(newMember);
+            memberRepository.save(newMember);
         } else {
             member = findMember.get();
         }

--- a/src/main/java/com/tickettimer/backendserver/domain/Member.java
+++ b/src/main/java/com/tickettimer/backendserver/domain/Member.java
@@ -31,13 +31,15 @@ public class Member {
     private String email;
 
     private String profileUrl;
+    private String password;
 
     @Builder
-    public Member(String serverId, String nickname, String email, String profileUrl) {
+    public Member(String serverId, String nickname, String email, String profileUrl, String password) {
         this.serverId=serverId;
         this.nickname=nickname;
         this.email=email;
         this.profileUrl=profileUrl;
+        this.password=password;
     }
 
 }

--- a/src/main/java/com/tickettimer/backendserver/dto/ResourceType.java
+++ b/src/main/java/com/tickettimer/backendserver/dto/ResourceType.java
@@ -1,0 +1,12 @@
+package com.tickettimer.backendserver.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+@AllArgsConstructor
+@Getter
+public enum ResourceType {
+    KAKAO("kakao"),
+    APPLE("apple");
+    private String name;
+
+}

--- a/src/main/java/com/tickettimer/backendserver/filter/AuthenticationExceptionFilter.java
+++ b/src/main/java/com/tickettimer/backendserver/filter/AuthenticationExceptionFilter.java
@@ -1,0 +1,55 @@
+package com.tickettimer.backendserver.filter;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.tickettimer.backendserver.dto.ResultResponse;
+import com.tickettimer.backendserver.dto.TokenInfo;
+import com.tickettimer.backendserver.exception.CustomNotFoundException;
+import com.tickettimer.backendserver.exception.InvalidTokenException;
+import io.jsonwebtoken.ExpiredJwtException;
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.web.client.HttpClientErrorException;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+import java.io.IOException;
+import java.io.PrintWriter;
+
+public class AuthenticationExceptionFilter extends OncePerRequestFilter {
+    private final ObjectMapper objectMapper;
+
+    public AuthenticationExceptionFilter(ObjectMapper objectMapper) {
+        this.objectMapper = objectMapper;
+    }
+    @Override
+    protected void doFilterInternal(
+            HttpServletRequest request,
+            HttpServletResponse response,
+            FilterChain filterChain
+    ) throws ServletException, IOException {
+        try {
+            filterChain.doFilter(request, response);
+        } catch (HttpClientErrorException.Unauthorized ex) {
+            writeErrorResponse(response, HttpStatus.UNAUTHORIZED.value(), ex.getMessage(), null);
+        }
+    }
+    private void writeErrorResponse(HttpServletResponse response, int status, String message, Object result) {
+        response.setStatus(status);
+        response.setContentType(MediaType.APPLICATION_JSON_VALUE);
+        response.setCharacterEncoding("utf-8");
+        ResultResponse res = ResultResponse.builder()
+                .code(status)
+                .message(message)
+                .result(result).build();
+        try {
+            String s = objectMapper.writeValueAsString(res);
+            PrintWriter writer = response.getWriter();
+            writer.write(s);
+        } catch (IOException ex) {
+            throw new RuntimeException(ex);
+        }
+    }
+}

--- a/src/main/java/com/tickettimer/backendserver/filter/JwtAuthenticationFilter.java
+++ b/src/main/java/com/tickettimer/backendserver/filter/JwtAuthenticationFilter.java
@@ -1,0 +1,186 @@
+package com.tickettimer.backendserver.filter;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.tickettimer.backendserver.auth.PrincipalDetails;
+import com.tickettimer.backendserver.domain.Member;
+import com.tickettimer.backendserver.dto.ResourceType;
+import com.tickettimer.backendserver.dto.ResultResponse;
+import com.tickettimer.backendserver.dto.TokenInfo;
+import com.tickettimer.backendserver.exception.CustomNotFoundException;
+import com.tickettimer.backendserver.service.JwtService;
+import com.tickettimer.backendserver.service.MemberService;
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.*;
+import org.springframework.security.authentication.AuthenticationManager;
+import org.springframework.security.authentication.InternalAuthenticationServiceException;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.AuthenticationException;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
+import org.springframework.stereotype.Component;
+import org.springframework.util.MultiValueMap;
+import org.springframework.web.client.RestTemplate;
+
+import java.io.IOException;
+import java.io.PrintWriter;
+import java.util.Map;
+import java.util.Optional;
+@Slf4j
+public class JwtAuthenticationFilter extends UsernamePasswordAuthenticationFilter {
+    private final AuthenticationManager authenticationManager;
+    private final MemberService memberService;
+    private final ObjectMapper objectMapper;
+    private final JwtService jwtService;
+    private final BCryptPasswordEncoder bCryptPasswordEncoder;
+
+    private final String password; // 회원 가입시 넣어줄 비밀번호. application.properties에서 관리
+    public JwtAuthenticationFilter(
+            AuthenticationManager authenticationManager,
+            MemberService memberService,
+            ObjectMapper objectMapper,
+            JwtService jwtService,
+            BCryptPasswordEncoder bCryptPasswordEncoder,
+            String password
+    ) {
+        this.authenticationManager = authenticationManager;
+        this.memberService = memberService;
+        this.objectMapper = objectMapper;
+        this.jwtService = jwtService;
+        this.bCryptPasswordEncoder = bCryptPasswordEncoder;
+        this.password = password;
+    }
+
+
+    //로그인을 시도할 때 실행
+    @Override
+    public Authentication attemptAuthentication(
+            HttpServletRequest request,
+            HttpServletResponse response
+    ) throws AuthenticationException {
+        String resource = request.getHeader("resource"); // resource server 이름 ex) 카카오, 애플
+        String accessToken = request.getHeader("Authorization");
+
+        // 카카오 로그인이라면
+        if (resource.equals(ResourceType.KAKAO.getName())) {
+            // header 생성
+            HttpHeaders httpHeaders = new HttpHeaders();
+            httpHeaders.add(HttpHeaders.AUTHORIZATION, accessToken);
+            httpHeaders.add(HttpHeaders.CONTENT_TYPE, "application/x-www-form-urlencoded;charset=utf-8");
+
+            HttpEntity<MultiValueMap<String, String>> httpEntity = new HttpEntity<>(httpHeaders);
+
+            // 사용자 정보 요청하기
+            RestTemplate restTemplate = new RestTemplate();
+            ResponseEntity<Object> memberInfo = restTemplate.exchange(
+                    "https://kapi.kakao.com/v2/user/me",
+                    HttpMethod.GET,
+                    httpEntity,
+                    Object.class
+            );
+            Map map = objectMapper.convertValue(memberInfo.getBody(), Map.class);
+            Map properties = objectMapper.convertValue(map.get("properties"), Map.class);
+            Map kakaoAccount = objectMapper.convertValue(map.get("kakao_account"), Map.class);
+
+            // 서버 식별 아이디
+            String serverId = "kakao" + map.get("id");
+
+            // 닉네임
+            String nickname = (String) properties.get("nickname");
+
+            // 이메일
+            String email = (String) kakaoAccount.get("email");
+
+            try{
+                // 해당 serverId 데이터베이스 존재 여부. 존재하지 않으면 CustomNotFoundException 반환
+                memberService.findByServerId(serverId);
+            } catch(CustomNotFoundException e) {
+                // 해당 유저가 데이터베이스에 없으면 회원가입 처리
+                // 비밀번호는 서버에서 만든 값
+                Member newMember = Member.builder()
+                        .serverId(serverId)
+                        .nickname(nickname)
+                        .password(bCryptPasswordEncoder.encode(password))
+                        .email(email).build();
+                memberService.save(newMember);
+
+            }
+            UsernamePasswordAuthenticationToken usernamePasswordAuthenticationToken = new UsernamePasswordAuthenticationToken(serverId, password);
+            Authentication authenticate = authenticationManager.authenticate(usernamePasswordAuthenticationToken);
+            return authenticate;
+
+        } else if (resource == ResourceType.APPLE.getName()){
+            // 애플 로그인
+            return null;
+        } else{
+            return null;
+        }
+    }
+    //인증을 성공하면 실행
+    //response Authorization header에 jwt를 담아서 보내줌
+    @Override
+    protected void successfulAuthentication(
+            HttpServletRequest request,
+            HttpServletResponse response,
+            FilterChain chain,
+            Authentication authResult)
+    {
+        PrincipalDetails principalDetails = (PrincipalDetails) authResult.getPrincipal();
+        Member member = principalDetails.getMember();
+        String serverAccessToken = jwtService.createAccessToken(
+                member.getServerId(),
+                member.getId()
+        );
+
+        String refreshToken = jwtService.createRefreshToken(member.getServerId(), member.getId());
+        TokenInfo tokenInfo = TokenInfo.builder()
+                .accessToken(serverAccessToken)
+                .refreshToken(refreshToken).build();
+        //서블릿으로 JSON 응답
+        response.setStatus(HttpServletResponse.SC_OK);
+        response.setContentType(MediaType.APPLICATION_JSON_VALUE);
+        response.setCharacterEncoding("utf-8");
+        ResultResponse res = ResultResponse.builder()
+                .code(HttpServletResponse.SC_OK)
+                .message("로그인 성공")
+                .result(tokenInfo).build();
+
+        log.info("{} : 로그인 성공", member.getServerId());
+        try {
+            String s = objectMapper.writeValueAsString(res);
+            PrintWriter writer = response.getWriter();
+            writer.write(s);
+        } catch (IOException ex) {
+            throw new RuntimeException(ex);
+        }
+    }
+//    @Override
+//    protected void unsuccessfulAuthentication(
+//            HttpServletRequest request,
+//            HttpServletResponse response,
+//            AuthenticationException failed
+//    ) {
+//        //비밀번호 틀림
+//        writeErrorResponse(response, HttpServletResponse.SC_BAD_REQUEST, failed.getMessage());
+//    }
+    private void writeErrorResponse(HttpServletResponse response, int status, String message) {
+        response.setStatus(status);
+        response.setContentType(MediaType.APPLICATION_JSON_VALUE);
+        response.setCharacterEncoding("utf-8");
+        ResultResponse res = ResultResponse.builder()
+                .code(status)
+                .message(message).build();
+        try {
+            String s = objectMapper.writeValueAsString(res);
+            PrintWriter writer = response.getWriter();
+            writer.write(s);
+        } catch (IOException ex) {
+            throw new RuntimeException(ex);
+        }
+    }
+}

--- a/src/main/java/com/tickettimer/backendserver/filter/JwtAuthorizationFilter.java
+++ b/src/main/java/com/tickettimer/backendserver/filter/JwtAuthorizationFilter.java
@@ -59,8 +59,9 @@ public class JwtAuthorizationFilter extends BasicAuthenticationFilter {
     ) throws IOException, ServletException {
         String jwt = request.getHeader("Authorization");
         //jwt가 없거나 Bearer로 시작하지 않으면 거부
-        if (jwt == null || !jwt.startsWith("Bearer")) {
-            String path =request.getContextPath() + request.getServletPath();
+        if (jwt == null || !jwt.startsWith("Bearer") ) {
+            System.out.println("login");
+            String path = request.getContextPath() + request.getServletPath();
             if (
                     path.equals("/login/oauth2/code/kakao") ||
                             path.equals("/api/oauth2/kakao")

--- a/src/main/java/com/tickettimer/backendserver/service/MemberService.java
+++ b/src/main/java/com/tickettimer/backendserver/service/MemberService.java
@@ -11,21 +11,29 @@ import java.util.Optional;
 @Service
 @RequiredArgsConstructor
 public class MemberService {
-//    private final MemberRepository memberRepository;
-//
-//    public Member save(Member member) {
-//        Optional<Member> save = memberRepository.save(member);
-//        return save.orElseThrow(
-//                () -> new CustomNotFoundException("memberId", member.getServerId())
-//        );
-//    }
-//
-//    public Member findById(Long id) {
-//        Optional<Member> findMember = memberRepository.findById(id);
-//        findMember.ifPresent(
-//                value->{
-//
-//                }
-//        );
-//    }
+    private final MemberRepository memberRepository;
+
+    public Member save(Member member) {
+        return memberRepository.save(member);
+    }
+
+    public Member findById(Long id) {
+        Optional<Member> findMember = memberRepository.findById(id);
+        return findMember.orElseThrow(
+                () -> new CustomNotFoundException("id", id.toString())
+        );
+    }
+
+    /**
+     *
+     * @param serverId resource server로부터 받은 serverId
+     * @return Member
+     * 해당 serverId가 없다면 NotFoundException 발생
+     */
+    public Member findByServerId(String serverId) {
+        Optional<Member> findMember = memberRepository.findByServerId(serverId);
+        return findMember.orElseThrow(
+                () -> new CustomNotFoundException("id", serverId)
+        );
+    }
 }


### PR DESCRIPTION
## 🌱 관련 이슈
- #4 
<!-- 관련있는 이슈 번호(#000)을 적어주세요. -->


## 🌱 구현/변경 사항 및 이유
1. 인증 부분 컨트롤러에서 필터로 변경
2. 멤버 엔티티 "password" 필드 추가
<!-- 구현/변경한 내용과 및 이유를 적어주세요. -->


## 🌱 PR Point

<!-- 리뷰어 분들이 집중적으로 보셨으면 하는 내용을 적어주세요 -->
처음에 컨트롤러에서 access token을 받아서 로그인을 처리하도록 구현했습니다.

그런데 시큐리티 필터를 사용 중인데 굳이 컨트롤러에서 처리할 필요가 없을 것 같아서 컨트롤러가 아닌 JwtAuthenticationFilter에서 로그인 처리하도록 변경했습니다.

멤버 엔티티 필드에 "password"가 추가되었습니다.

Authentication Provider에서 유저 정보를 비교하는 과정에서 비밀번호가 필요해서 필드에 password 추가했습니다.

이 비밀번호는 application.properties에 저장해두고 resource server에 따라서 다른 비밀번호를 주었습니다.

## 🌱 스크린샷

<!-- 참고할 스크린샷을 넣어주세요. -->


## 🌱 참고한 코드 출처
- []()
<!-- 참고한 코드의 출처를 작성해주세요 -->
